### PR TITLE
Reference correct location of the module server.js invoked by npm run dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   ],
   "scripts": {
     "test": "NODE_ENV=test nyc --reporter=lcov --reporter=text --reporter=text-summary mocha test/*test.js",
-    "dev": "nodemon test/test-server/server/server.js --ignore db.json --ext js,json",
+    "dev": "nodemon test/test-server/server.js --ignore db.json --ext js,json",
     "lint": "eslint .",
     "pretest": "npm run lint",
     "test:watch": "npm run test -- -w",


### PR DESCRIPTION
The file referenced by the `run` script in package.json is moved, this PR updates it to the right location.